### PR TITLE
pthread library missing.

### DIFF
--- a/vlfeat_slic_cli/CMakeLists.txt
+++ b/vlfeat_slic_cli/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(../lib_vlfeat/)
 
 find_package(OpenCV REQUIRED)
-
+find_package(Threads)
 add_executable(vlfeat_slic_example main.cpp)
-target_link_libraries(vlfeat_slic_example ${OpenCV_LIBS} vlfeat_slic)
+target_link_libraries(vlfeat_slic_example ${OpenCV_LIBS} vlfeat_slic pthread)


### PR DESCRIPTION
RIght now If I follow your steps, I get the following error.

```
isler@gambit:~/work/SuperPixels/vlfeat-slic-example_d/build$ make
[ 80%] Built target vlfeat_slic
Linking CXX executable ../../bin/vlfeat_slic_example
/usr/bin/ld: ../libvlfeat_slic.a(generic.c.o): undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [../bin/vlfeat_slic_example] Error 1
make[1]: *** [vlfeat_slic_cli/CMakeFiles/vlfeat_slic_example.dir/all] Error 2
make: *** [all] Error 2

```

So I included the missing library in this pull request.
